### PR TITLE
Corrected Image create_from_data to set_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # gd-avif
 Godot extension to support AVIF images.
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 # gd-avif
 Godot extension to support AVIF images.
-

--- a/src/image_loader_avif.cpp
+++ b/src/image_loader_avif.cpp
@@ -63,7 +63,7 @@ Error ImageLoaderAVIF::avif_load_image_from_buffer(Image *p_image, const uint8_t
 	result = avifImageYUVToRGB(p_decoder->image, &rgb);
 	ERR_FAIL_COND_V_MSG(result != AVIF_RESULT_OK, FAILED, avifResultToString(result));
 
-	p_image->create_from_data(width, height, false, Image::FORMAT_RGBA8, data);
+	p_image->set_data(width, height, false, Image::FORMAT_RGBA8, data);
 	return OK;
 }
 


### PR DESCRIPTION
Found this issue that caused an empty image to be returned by ImageLoader. This works with the code setup as a module.

The MacOS arm64 GDE version still hangs at open - I haven't checked any other platform.